### PR TITLE
Add Claude Code support and improve safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 npm install -g mcp-sync
 
 # または、リポジトリをクローンして直接使用
-git clone https://github.com/yourusername/sync-mcp-config.git
+git clone https://github.com/sodeyama/sync-mcp-config.git
 cd sync-mcp-config
 npm install
 npm link
@@ -56,6 +56,8 @@ mcp-sync sync
 
 ```bash
 mcp-sync sync --tool claude cline roo
+# または claude-code も含める場合
+mcp-sync sync --tool claude claude-code cline
 ```
 
 #### 特定のツールから他のツールに同期
@@ -68,6 +70,12 @@ mcp-sync sync --source claude
 
 ```bash
 mcp-sync sync --dry-run
+```
+
+#### 強制同期（競合を無視）
+
+```bash
+mcp-sync sync --force
 ```
 
 ### バックアップ
@@ -112,6 +120,12 @@ mcp-sync restore --tool claude --list
 mcp-sync status
 ```
 
+詳細なログを表示する場合：
+
+```bash
+mcp-sync status --verbose
+```
+
 ### 設定編集
 
 マスター設定ファイルをエディタで開く：
@@ -126,11 +140,11 @@ mcp-sync edit
 - **バックアップ**: `~/.mcp/backups/`
 - **各ツールの設定**:
   - Claude Desktop: `~/Library/Application Support/Claude/claude_desktop_config.json`
-  - Claude Code: `~/.claude.json` (mcpServersセクション)
+  - Claude Code: `~/.claude.json` (mcpServersセクション) ※他の設定と共有されるファイルのため、既存設定は保持されます
   - Cline: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
   - Roo Code: `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json`
   - Cursor: `~/.cursor/mcp.json`
-  - VS Code: `~/Library/Application Support/Code/User/settings.json`
+  - VS Code: `~/Library/Application Support/Code/User/settings.json` (mcp.serversセクション)
 
 ## マスター設定ファイルの形式
 
@@ -162,22 +176,27 @@ mcp-sync edit
 }
 ```
 
-## 高度な使用方法
+## コマンドラインオプション
 
-### プログラマティックAPI
+### グローバルオプション
 
-```typescript
-import { createSyncEngine, syncAll, syncFrom } from 'mcp-sync';
+- `--verbose`, `-v`: 詳細なログを表示
+- `--quiet`, `-q`: エラー以外のメッセージを抑制
 
-// 全ツールに同期
-await syncAll({ dryRun: false });
+### 各コマンドのオプション
 
-// 特定のツールから同期
-await syncFrom('claude', {
-  tools: ['cline', 'roo'],
-  skipBackup: false
-});
-```
+- **init**: `--force` (既存の設定を上書き)
+- **sync**: 
+  - `--tool <tools...>` (特定のツールのみ同期)
+  - `--source <tool>` (マスターではなく特定のツールから同期)
+  - `--dry-run` (変更をプレビュー)
+  - `--skip-backup` (バックアップをスキップ)
+  - `--force` (競合を無視して強制同期)
+- **backup**: `--tool <tools...>` (特定のツールのみバックアップ)
+- **restore**: 
+  - `--tool <tool>` (必須：復元するツール)
+  - `--id <backupId>` (特定のバックアップID)
+  - `--list` (利用可能なバックアップを一覧表示)
 
 ## トラブルシューティング
 
@@ -205,6 +224,10 @@ chmod 644 ~/Library/Application\ Support/Claude/claude_desktop_config.json
 mcp-sync sync --force
 ```
 
+### Claude Codeの設定について
+
+Claude Codeは`~/.claude.json`ファイルの`mcpServers`セクションにMCP設定を保存します。このファイルには他の設定（globalShortcut、themeなど）も含まれているため、MCP Syncは`mcpServers`セクションのみを更新し、他の設定は保持します。
+
 ## 開発
 
 ### ビルド
@@ -216,7 +239,17 @@ npm run build
 ### テスト
 
 ```bash
+# 全テストを実行
 npm test
+
+# ウォッチモードでテスト
+npm run test:watch
+
+# カバレッジレポート付きでテスト
+npm run test:coverage
+
+# 特定のテストファイルのみ実行
+npm test -- path/to/test.spec.ts
 ```
 
 ### 開発モード
@@ -225,10 +258,20 @@ npm test
 npm run dev
 ```
 
+### コード品質
+
+```bash
+# Lintを実行
+npm run lint
+
+# コードフォーマット
+npm run format
+```
+
 ## ライセンス
 
 MIT License
 
 ## 貢献
 
-プルリクエストを歓迎します！バグ報告や機能リクエストは[Issues](https://github.com/yourusername/sync-mcp-config/issues)までお願いします。
+プルリクエストを歓迎します！バグ報告や機能リクエストは[Issues](https://github.com/sodeyama/sync-mcp-config/issues)までお願いします。

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## 対応ツール
 
 - **Claude Desktop**
+- **Claude Code**
 - **Cline**
 - **Roo Code**
 - **Cursor**
@@ -125,6 +126,7 @@ mcp-sync edit
 - **バックアップ**: `~/.mcp/backups/`
 - **各ツールの設定**:
   - Claude Desktop: `~/Library/Application Support/Claude/claude_desktop_config.json`
+  - Claude Code: `~/.claude.json` (mcpServersセクション)
   - Cline: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
   - Roo Code: `~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json`
   - Cursor: `~/.cursor/mcp.json`

--- a/src/core/BackupManager.ts
+++ b/src/core/BackupManager.ts
@@ -112,7 +112,7 @@ export class BackupManager {
   async listBackups(tool?: ToolType): Promise<BackupInfo[]> {
     try {
       const backups: BackupInfo[] = [];
-      const tools = tool ? [tool] : ['claude', 'cline', 'roo', 'cursor', 'vscode'] as ToolType[];
+      const tools = tool ? [tool] : ['claude', 'cline', 'roo', 'cursor', 'vscode', 'claude-code'] as ToolType[];
 
       for (const t of tools) {
         const toolBackupDir = path.join(this.backupDir, t);

--- a/src/utils/PathResolver.ts
+++ b/src/utils/PathResolver.ts
@@ -67,7 +67,7 @@ export class PathResolver {
       roo: '~/Library/Application Support/Code/User/globalStorage/rooveterinaryinc.roo-cline/settings/mcp_settings.json',
       cursor: '~/.cursor/mcp.json',
       vscode: '~/Library/Application Support/Code/User/settings.json',
-      'claude-code': '~/.claude/settings.json',
+      'claude-code': '~/.claude.json',
     };
 
     const configPath = configPaths[tool];


### PR DESCRIPTION
## Summary
- Add support for Claude Code (claude.ai/code) as a new synchronization target
- Ensure Claude Code's shared configuration file (~/.claude.json) is safely updated without affecting other settings
- Update documentation to reflect current project state

## Changes
1. **Claude Code Support**
   - Add ClaudeCodeConverter for bidirectional sync
   - Update config path from ~/.claude/settings.json to ~/.claude.json
   - Add claude-code to BackupManager's supported tools list

2. **Safety Improvements**
   - Implement merge strategy in ClaudeCodeConverter to preserve existing settings
   - Add comprehensive test to verify other settings (globalShortcut, theme, etc.) are not overwritten
   - Ensure only mcpServers section is modified in shared config files

3. **Documentation Updates**
   - Add Claude Code to supported tools list
   - Document all CLI options and commands
   - Update GitHub repository URLs
   - Add troubleshooting section for Claude Code

## Test Plan
- [x] All existing tests pass
- [x] New test verifies Claude Code settings preservation
- [x] Manual testing of Claude Code sync functionality
- [x] Verify backup/restore works for Claude Code

🤖 Generated with [Claude Code](https://claude.ai/code)